### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "parcel-bundler": "1.7.0"
+    "parcel-bundler": "^1.7.0"
   }
 }


### PR DESCRIPTION
The constructor has changed (pkg was removed from HTMLAsset https://github.com/parcel-bundler/parcel/blame/81151bbc2d493d8a713e8858ac34ede41f6cd3f1/src/assets/HTMLAsset.js#L81) and as a result, the plugin doesn't work with Parcel 1.9.0+

https://github.com/parcel-bundler/parcel/commit/2f7be14aa9eea3fa9e8ee61591c001937d9757a1